### PR TITLE
Adding support for Basic.qos for fair dispatch

### DIFF
--- a/PSRabbitMq/Connect-RabbitMqChannel.ps1
+++ b/PSRabbitMq/Connect-RabbitMqChannel.ps1
@@ -40,41 +40,42 @@
 
         $Connection,
 
-        [parameter(Mandatory = $True)]
+        [parameter(Mandatory = $True, ValueFromPipelineByPropertyName = $true)]
+        [AllowEmptyString()]
         [string]$Exchange,
 
-        [parameter(ParameterSetName = 'NoQueueNameWithBasicQoS',Mandatory = $true)]
-        [parameter(ParameterSetName = 'NoQueueName',Mandatory = $true)]
-        [parameter(ParameterSetName = 'QueueName',Mandatory = $false)]
-        [parameter(parameterSetName = 'QueueNameWithBasicQoS',Mandatory = $false)]
+        [parameter(ParameterSetName = 'NoQueueNameWithBasicQoS',Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
+        [parameter(ParameterSetName = 'NoQueueName',Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
+        [parameter(ParameterSetName = 'QueueName',Mandatory = $false, ValueFromPipelineByPropertyName = $true)]
+        [parameter(parameterSetName = 'QueueNameWithBasicQoS',Mandatory = $false, ValueFromPipelineByPropertyName = $true)]
         [string]$Key,
 
         [parameter(ParameterSetName = 'QueueName',
-                   Mandatory = $True)]
+                   Mandatory = $True,ValueFromPipelineByPropertyName = $true)]
         [parameter(parameterSetName = 'QueueNameWithBasicQoS',
-                   Mandatory = $True)]
+                   Mandatory = $True,ValueFromPipelineByPropertyName = $true)]
         [string]$QueueName,
 
-        [parameter(ParameterSetName = 'QueueName')]
-        [parameter(parameterSetName = 'QueueNameWithBasicQoS')]
+        [parameter(ParameterSetName = 'QueueName',ValueFromPipelineByPropertyName = $true)]
+        [parameter(parameterSetName = 'QueueNameWithBasicQoS',ValueFromPipelineByPropertyName = $true)]
         [bool]$Durable = $true,
 
-        [parameter(ParameterSetName = 'QueueName')]
-        [parameter(parameterSetName = 'QueueNameWithBasicQoS')]
+        [parameter(ParameterSetName = 'QueueName',ValueFromPipelineByPropertyName = $true)]
+        [parameter(parameterSetName = 'QueueNameWithBasicQoS',ValueFromPipelineByPropertyName = $true)]
         [bool]$Exclusive = $False,
 
-        [parameter(ParameterSetName = 'QueueName')]
-        [parameter(parameterSetName = 'QueueNameWithBasicQoS')]
+        [parameter(ParameterSetName = 'QueueName',ValueFromPipelineByPropertyName = $true)]
+        [parameter(parameterSetName = 'QueueNameWithBasicQoS',ValueFromPipelineByPropertyName = $true)]
         [bool]$AutoDelete = $False,
         
-        [parameter(parameterSetName = 'QueueNameWithBasicQoS',Mandatory = $true)]
-        [parameter(ParameterSetName = 'NoQueueNameWithBasicQoS',Mandatory = $true)]
+        [parameter(parameterSetName = 'QueueNameWithBasicQoS',Mandatory = $true,ValueFromPipelineByPropertyName = $true)]
+        [parameter(ParameterSetName = 'NoQueueNameWithBasicQoS',Mandatory = $true,ValueFromPipelineByPropertyName = $true)]
         [uint32]$prefetchSize,
-        [parameter(parameterSetName = 'QueueNameWithBasicQoS',Mandatory = $true)]
-        [parameter(ParameterSetName = 'NoQueueNameWithBasicQoS',Mandatory = $true)]
+        [parameter(parameterSetName = 'QueueNameWithBasicQoS',Mandatory = $true,ValueFromPipelineByPropertyName = $true)]
+        [parameter(ParameterSetName = 'NoQueueNameWithBasicQoS',Mandatory = $true,ValueFromPipelineByPropertyName = $true)]
         [uint16]$prefetchCount,
-        [parameter(parameterSetName = 'QueueNameWithBasicQoS',Mandatory = $true)]
-        [parameter(ParameterSetName = 'NoQueueNameWithBasicQoS',Mandatory = $true)]
+        [parameter(parameterSetName = 'QueueNameWithBasicQoS',Mandatory = $true,ValueFromPipelineByPropertyName = $true)]
+        [parameter(ParameterSetName = 'NoQueueNameWithBasicQoS',Mandatory = $true,ValueFromPipelineByPropertyName = $true)]
         [switch]$global
     )
     Try

--- a/PSRabbitMq/Connect-RabbitMqChannel.ps1
+++ b/PSRabbitMq/Connect-RabbitMqChannel.ps1
@@ -31,6 +31,17 @@
     .PARAMETER AutoDelete
         If queuename is specified, this needs to match whether it is AutoDelete
 
+    .PARAMETER prefetchSize
+        Maximum amount of content (measured in octets) that the server will deliver, 0 if unlimited
+
+        https://www.rabbitmq.com/consumer-prefetch.html
+
+    .PARAMETER prefetchCount
+        maximum number of unacknowledged messages that the server will deliver to a channel/consumers, 0 if unlimited
+
+    .PARAMETER global
+        true if the settings should be applied to the entire channel rather than each consumer
+
     .EXAMPLE
         $Channel = Connect-RabbitMqChannel -Connection $Connection -Exchange MyExchange -Key MyQueue
  #>

--- a/PSRabbitMq/Connect-RabbitMqChannel.ps1
+++ b/PSRabbitMq/Connect-RabbitMqChannel.ps1
@@ -109,7 +109,7 @@
         if($PsCmdlet.ParameterSetName.Contains('BasicQoS')) {
          $channel.BasicQos($prefetchSize,$prefetchCount,$global)
         }
-        #Bind our queue to the ServerBuilds exchange
+        #Bind our queue to the $exchange
         $Channel.QueueBind($QueueName, $Exchange, $Key)
         $Channel
     }

--- a/PSRabbitMq/Connect-RabbitMqChannel.ps1
+++ b/PSRabbitMq/Connect-RabbitMqChannel.ps1
@@ -33,8 +33,8 @@
 
     .EXAMPLE
         $Channel = Connect-RabbitMqChannel -Connection $Connection -Exchange MyExchange -Key MyQueue
-#>
-
+ #>
+    [outputType([RabbitMQ.Client.Framing.Impl.Model])]
     [cmdletbinding(DefaultParameterSetName = 'NoQueueName')]
     param(
 
@@ -43,22 +43,39 @@
         [parameter(Mandatory = $True)]
         [string]$Exchange,
 
+        [parameter(ParameterSetName = 'NoQueueNameWithBasicQoS',Mandatory = $true)]
         [parameter(ParameterSetName = 'NoQueueName',Mandatory = $true)]
         [parameter(ParameterSetName = 'QueueName',Mandatory = $false)]
+        [parameter(parameterSetName = 'QueueNameWithBasicQoS',Mandatory = $false)]
         [string]$Key,
 
         [parameter(ParameterSetName = 'QueueName',
                    Mandatory = $True)]
+        [parameter(parameterSetName = 'QueueNameWithBasicQoS',
+                   Mandatory = $True)]
         [string]$QueueName,
 
         [parameter(ParameterSetName = 'QueueName')]
+        [parameter(parameterSetName = 'QueueNameWithBasicQoS')]
         [bool]$Durable = $true,
 
         [parameter(ParameterSetName = 'QueueName')]
+        [parameter(parameterSetName = 'QueueNameWithBasicQoS')]
         [bool]$Exclusive = $False,
 
         [parameter(ParameterSetName = 'QueueName')]
-        [bool]$AutoDelete = $False
+        [parameter(parameterSetName = 'QueueNameWithBasicQoS')]
+        [bool]$AutoDelete = $False,
+        
+        [parameter(parameterSetName = 'QueueNameWithBasicQoS',Mandatory = $true)]
+        [parameter(ParameterSetName = 'NoQueueNameWithBasicQoS',Mandatory = $true)]
+        [uint32]$prefetchSize,
+        [parameter(parameterSetName = 'QueueNameWithBasicQoS',Mandatory = $true)]
+        [parameter(ParameterSetName = 'NoQueueNameWithBasicQoS',Mandatory = $true)]
+        [uint16]$prefetchCount,
+        [parameter(parameterSetName = 'QueueNameWithBasicQoS',Mandatory = $true)]
+        [parameter(ParameterSetName = 'NoQueueNameWithBasicQoS',Mandatory = $true)]
+        [switch]$global
     )
     Try
     {
@@ -77,7 +94,9 @@
         {
             $QueueResult = $Channel.QueueDeclare()
         }
-
+        if($PsCmdlet.ParameterSetName.Contains('BasicQoS')) {
+         $channel.BasicQos($prefetchSize,$prefetchCount,$global)
+        }
         #Bind our queue to the ServerBuilds exchange
         $Channel.QueueBind($QueueName, $Exchange, $Key)
         $Channel

--- a/PSRabbitMq/Connect-RabbitMqChannel.ps1
+++ b/PSRabbitMq/Connect-RabbitMqChannel.ps1
@@ -13,7 +13,7 @@
         Optional PSCredential to connect to RabbitMq with
 
     .PARAMETER Key
-        Routing Key to look for
+        Routing Keys to look for
 
         If you specify a QueueName and no Key, we use the QueueName as the key
 
@@ -30,17 +30,6 @@
 
     .PARAMETER AutoDelete
         If queuename is specified, this needs to match whether it is AutoDelete
-
-    .PARAMETER prefetchSize
-        Maximum amount of content (measured in octets) that the server will deliver, 0 if unlimited
-
-        https://www.rabbitmq.com/consumer-prefetch.html
-
-    .PARAMETER prefetchCount
-        maximum number of unacknowledged messages that the server will deliver to a channel/consumers, 0 if unlimited
-
-    .PARAMETER global
-        true if the settings should be applied to the entire channel rather than each consumer
 
     .EXAMPLE
         $Channel = Connect-RabbitMqChannel -Connection $Connection -Exchange MyExchange -Key MyQueue
@@ -59,7 +48,7 @@
         [parameter(ParameterSetName = 'NoQueueName',Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
         [parameter(ParameterSetName = 'QueueName',Mandatory = $false, ValueFromPipelineByPropertyName = $true)]
         [parameter(parameterSetName = 'QueueNameWithBasicQoS',Mandatory = $false, ValueFromPipelineByPropertyName = $true)]
-        [string]$Key,
+        [string[]]$Key,
 
         [parameter(ParameterSetName = 'QueueName',
                    Mandatory = $True,ValueFromPipelineByPropertyName = $true)]
@@ -109,8 +98,10 @@
         if($PsCmdlet.ParameterSetName.Contains('BasicQoS')) {
          $channel.BasicQos($prefetchSize,$prefetchCount,$global)
         }
-        #Bind our queue to the $exchange
-        $Channel.QueueBind($QueueName, $Exchange, $Key)
+        #Bind our queue to the ServerBuilds exchange
+        foreach ($keyItem in $key) {
+            $Channel.QueueBind($QueueName, $Exchange, $KeyItem)
+        }
         $Channel
     }
     Catch

--- a/PSRabbitMq/New-RabbitMqConnectionFactory.ps1
+++ b/PSRabbitMq/New-RabbitMqConnectionFactory.ps1
@@ -1,42 +1,44 @@
 ﻿Function New-RabbitMqConnectionFactory {
-<#
-.SYNOPSIS
+ <#
+   .SYNOPSIS
     Create a RabbitMQ client connection
 
-.DESCRIPTION
+   .DESCRIPTION
     Create a RabbitMQ client connection
 
     Builds a RabbitMQ.Client.ConnectionFactory based on parameters, invokes CreateConnection method.
 
-.PARAMETER ComputerName
+   .PARAMETER ComputerName
     RabbitMq host
 
     If SSL is specified, we use this as the SslOption server name as well.
 
-.PARAMETER Credential
+   .PARAMETER Credential
     Optional PSCredential to connect to RabbitMq with
 
-.PARAMETER Ssl
+   .PARAMETER Ssl
     Optional Ssl version to connect to RabbitMq with
 
     If specified, we use ComputerName as the SslOption ServerName property.
 
-.EXAMPLE
+   .EXAMPLE
     $Connection = New-RabbitMqConnectionFactory -ComputerName RabbitMq.Contoso.com -Ssl Tls12 -Credential $Credential
 
     # Connect to RabbitMq.contoso.com over SSL (use tls 1.2), with credentials in $Credential
 
-.EXAMPLE
+   .EXAMPLE
     $Connection = New-RabbitMqConnectionFactory -ComputerName RabbitMq.Contoso.com
 
     # Connect to RabbitMq.contoso.com
-#>
+ #>
 
     [cmdletbinding()]
     param(
         [string]$ComputerName,
         [PSCredential]$Credential,
-        [System.Security.Authentication.SslProtocols]$Ssl
+        [System.Security.Authentication.SslProtocols]$Ssl,
+        [parameter(Mandatory = $false)]
+        [string]$vhost
     )
     Try
     {
@@ -45,6 +47,11 @@
         #Add the hostname
         $HostNameProp = [RabbitMQ.Client.ConnectionFactory].GetField("HostName")
         $HostNameProp.SetValue($Factory, $ComputerName)
+        
+        if($vhost) {
+         $vhostProp = [RabbitMQ.Client.ConnectionFactory].GetProperty("VirtualHost")
+         $vhostProp.SetValue($Factory, $vhost)
+        }
     
         #Add cred and SSL info
         if($Credential)

--- a/PSRabbitMq/New-RabbitMqConnectionFactory.ps1
+++ b/PSRabbitMq/New-RabbitMqConnectionFactory.ps1
@@ -21,6 +21,9 @@
 
     If specified, we use ComputerName as the SslOption ServerName property.
 
+   .PARAMETER vhost
+    create a connection via the specified virtual host, default is /
+
    .EXAMPLE
     $Connection = New-RabbitMqConnectionFactory -ComputerName RabbitMq.Contoso.com -Ssl Tls12 -Credential $Credential
 

--- a/PSRabbitMq/Register-RabbitMqEvent.ps1
+++ b/PSRabbitMq/Register-RabbitMqEvent.ps1
@@ -52,6 +52,17 @@
 
         If specified, we use ComputerName as the SslOption ServerName property.
 
+    .PARAMETER prefetchSize
+        Maximum amount of content (measured in octets) that the server will deliver, 0 if unlimited
+
+        https://www.rabbitmq.com/consumer-prefetch.html
+
+    .PARAMETER prefetchCount
+        maximum number of unacknowledged messages that the server will deliver to a channel/consumers, 0 if unlimited
+
+    .PARAMETER global
+        true if the settings should be applied to the entire channel rather than each consumer
+
     .EXAMPLE
         Register-RabbitMqEvent -ComputerName RabbitMq.Contoso.com -Exchange TestFanExc -Key 'wat' -Credential $Credential -Ssl Tls12 -QueueName TestQueue -Action {"HI! $_"}
 

--- a/PSRabbitMq/Register-RabbitMqEvent.ps1
+++ b/PSRabbitMq/Register-RabbitMqEvent.ps1
@@ -15,7 +15,7 @@
         RabbitMq Exchange
 
     .PARAMETER Key
-        Routing Key to look for
+        Routing Keys to look for
 
         If you specify a QueueName and no Key, we use the QueueName as the key
 
@@ -52,17 +52,6 @@
 
         If specified, we use ComputerName as the SslOption ServerName property.
 
-    .PARAMETER prefetchSize
-        Maximum amount of content (measured in octets) that the server will deliver, 0 if unlimited
-
-        https://www.rabbitmq.com/consumer-prefetch.html
-
-    .PARAMETER prefetchCount
-        maximum number of unacknowledged messages that the server will deliver to a channel/consumers, 0 if unlimited
-
-    .PARAMETER global
-        true if the settings should be applied to the entire channel rather than each consumer
-
     .EXAMPLE
         Register-RabbitMqEvent -ComputerName RabbitMq.Contoso.com -Exchange TestFanExc -Key 'wat' -Credential $Credential -Ssl Tls12 -QueueName TestQueue -Action {"HI! $_"}
 
@@ -84,7 +73,7 @@
         [parameter(ParameterSetName = 'NoQueueNameWithBasicQoS',Mandatory = $true)]
         [parameter(ParameterSetName = 'QueueName',Mandatory = $false)]
         [parameter(parameterSetName = 'QueueNameWithBasicQoS')]
-        [string]$Key,
+        [string[]]$Key,
 
         [parameter(ParameterSetName = 'QueueName',
                    Mandatory = $True)]

--- a/PSRabbitMq/Register-RabbitMqEvent.ps1
+++ b/PSRabbitMq/Register-RabbitMqEvent.ps1
@@ -66,6 +66,7 @@
         [string]$ComputerName = $Script:RabbitMqConfig.ComputerName,
 
         [parameter(Mandatory = $True)]
+        [AllowEmptyString()]
         [string]$Exchange,
 
         [parameter(ParameterSetName = 'NoQueueName',Mandatory = $true)]

--- a/PSRabbitMq/Register-RabbitMqEvent.ps1
+++ b/PSRabbitMq/Register-RabbitMqEvent.ps1
@@ -69,20 +69,27 @@
         [string]$Exchange,
 
         [parameter(ParameterSetName = 'NoQueueName',Mandatory = $true)]
+        [parameter(ParameterSetName = 'NoQueueNameWithBasicQoS',Mandatory = $true)]
         [parameter(ParameterSetName = 'QueueName',Mandatory = $false)]
+        [parameter(parameterSetName = 'QueueNameWithBasicQoS')]
         [string]$Key,
 
         [parameter(ParameterSetName = 'QueueName',
                    Mandatory = $True)]
+        [parameter(parameterSetName = 'QueueNameWithBasicQoS',
+                   Mandatory = $True)]
         [string]$QueueName,
 
         [parameter(ParameterSetName = 'QueueName')]
+        [parameter(parameterSetName = 'QueueNameWithBasicQoS')]
         [bool]$Durable = $true,
 
         [parameter(ParameterSetName = 'QueueName')]
+        [parameter(parameterSetName = 'QueueNameWithBasicQoS')]
         [bool]$Exclusive = $False,
 
         [parameter(ParameterSetName = 'QueueName')]
+        [parameter(parameterSetName = 'QueueNameWithBasicQoS')]
         [bool]$AutoDelete = $False,
 
         [switch]$RequireAck,
@@ -93,7 +100,17 @@
 
         [PSCredential]$Credential,
 
-        [System.Security.Authentication.SslProtocols]$Ssl
+        [System.Security.Authentication.SslProtocols]$Ssl,
+        
+        [parameter(parameterSetName = 'QueueNameWithBasicQoS',Mandatory = $true)]
+        [parameter(ParameterSetName = 'NoQueueNameWithBasicQoS',Mandatory = $true)]
+        [uint32]$prefetchSize,
+        [parameter(parameterSetName = 'QueueNameWithBasicQoS',Mandatory = $true)]
+        [parameter(ParameterSetName = 'NoQueueNameWithBasicQoS',Mandatory = $true)]
+        [uint16]$prefetchCount,
+        [parameter(parameterSetName = 'QueueNameWithBasicQoS',Mandatory = $true)]
+        [parameter(ParameterSetName = 'NoQueueNameWithBasicQoS',Mandatory = $true)]
+        [switch]$global
     )
 
     $ArgList = $ComputerName, $Exchange, $Key, $Action, $Credential, $Ssl, $LoopInterval, $QueueName, $Durable, $Exclusive, $AutoDelete, $RequireAck
@@ -110,7 +127,10 @@
             $Durable,
             $Exclusive,
             $AutoDelete,
-            $RequireAck
+            $RequireAck,
+            $prefetchSize,
+            $prefetchCount,
+            $global
         )
 
         $ActionSB = [System.Management.Automation.ScriptBlock]::Create($Action)
@@ -130,6 +150,11 @@
                 $ChanParams.Add('Durable' ,$Durable)
                 $ChanParams.Add('Exclusive',$Exclusive)
                 $ChanParams.Add('AutoDelete' ,$AutoDelete)
+            }
+            if($PsCmdlet.ParameterSetName.Contains('BasicQoS')) {
+                $ChanParams.Add('prefetchSize',$prefetchSize)
+                $ChanParams.Add('prefetchCount',$prefetchCount)
+                $ChanParams.Add('global',$global)
             }
             
 

--- a/PSRabbitMq/Register-RabbitMqEvent.ps1
+++ b/PSRabbitMq/Register-RabbitMqEvent.ps1
@@ -113,7 +113,7 @@
         [switch]$global
     )
 
-    $ArgList = $ComputerName, $Exchange, $Key, $Action, $Credential, $Ssl, $LoopInterval, $QueueName, $Durable, $Exclusive, $AutoDelete, $RequireAck
+    $ArgList = $ComputerName, $Exchange, $Key, $Action, $Credential, $Ssl, $LoopInterval, $QueueName, $Durable, $Exclusive, $AutoDelete, $RequireAck,$prefetchSize,$prefetchCount,$global
     Start-Job -Name "RabbitMq_${ComputerName}_${Exchange}_${Key}" -ArgumentList $Arglist -ScriptBlock {
         param(
             $ComputerName,
@@ -151,7 +151,7 @@
                 $ChanParams.Add('Exclusive',$Exclusive)
                 $ChanParams.Add('AutoDelete' ,$AutoDelete)
             }
-            if($PsCmdlet.ParameterSetName.Contains('BasicQoS')) {
+            if($prefetchSize) {
                 $ChanParams.Add('prefetchSize',$prefetchSize)
                 $ChanParams.Add('prefetchCount',$prefetchCount)
                 $ChanParams.Add('global',$global)

--- a/PSRabbitMq/Send-RabbitMqMessage.ps1
+++ b/PSRabbitMq/Send-RabbitMqMessage.ps1
@@ -38,6 +38,9 @@
 
         If specified, we use ComputerName as the SslOption ServerName property.
 
+    .PARAMETER vhost
+        create a connection via the specified virtual host, default is /
+
     .EXAMPLE
         Send-RabbitMqMessage -ComputerName RabbitMq.Contoso.com -Exchange MyExchange -Key "wat" -InputObject $Object
 

--- a/PSRabbitMq/Send-RabbitMqMessage.ps1
+++ b/PSRabbitMq/Send-RabbitMqMessage.ps1
@@ -68,7 +68,10 @@
 
         [PSCredential]$Credential,
 
-        [System.Security.Authentication.SslProtocols]$Ssl
+        [System.Security.Authentication.SslProtocols]$Ssl,
+
+        [parameter(Mandatory = $false)]
+        [string]$vhost
     )
     begin
     {
@@ -78,6 +81,7 @@
         {
             'Ssl'        { $ConnParams.Add('Ssl',$Ssl) }
             'Credential' { $ConnParams.Add('Credential',$Credential) }
+            'vhost' { $ConnParams.Add('vhost',$vhost) }
         }
         Write-Verbose "Connection parameters: $($ConnParams | Out-String)"
 


### PR DESCRIPTION
Hi,

Thanks for the nice module, very useful.
I needed it to support fair dispatch between consumers on a single queue using Register-RabbitMQEvent, hence the PR.
https://www.rabbitmq.com/tutorials/tutorial-two-dotnet.html

I added parameter sets, so it's fully backward compatible / only optional.

Let me know if any question.
Gael