### PR TITLE
Set-RabbitMqConfig Access Denied for Non-Elevated User Fix

### DIFF
--- a/PSRabbitMq/Get-RabbitMqConfig.ps1
+++ b/PSRabbitMq/Get-RabbitMqConfig.ps1
@@ -10,23 +10,26 @@
         Config source:
         RabbitMqConfig to view module variable
         PSRabbitMq.xml to view PSRabbitMq.xml from "$env:APPDATA\PSRabbitMq.xml"
+        CurrentUser to view PSRabbitMq.xml from "$env:APPDATA\PSRabbitMq.xml"
+        System to view PSRabbitMq.xml from "$env:PROGRAMDATA\PSRabbitMq.xml"
 
     .FUNCTIONALITY
         RabbitMq
     #>
     [cmdletbinding()]
     param(
-        [ValidateSet('RabbitMqConfig','PSRabbitMq.xml')]
+        [ValidateSet('RabbitMqConfig','PSRabbitMq.xml','CurrentUser','System')]
         [string]$Source = "RabbitMqConfig"
     )
     
-    if($Source -eq "RabbitMqConfig")
-    {
+    if($Source -eq "RabbitMqConfig"){
         $Script:RabbitMqConfig
     }
-    else
-    {
+    elseif($Source -eq "PSRabbitMq.xml" -or $Source -eq "CurrentUser"){
         Import-Clixml -Path "$env:APPDATA\PSRabbitMq.xml"
+    }
+    elseif($Source -eq "System"){
+        Import-Clixml -Path "$env:PROGRAMDATA\PSRabbitMq.xml"
     }
 
 }

--- a/PSRabbitMq/Get-RabbitMqConfig.ps1
+++ b/PSRabbitMq/Get-RabbitMqConfig.ps1
@@ -9,7 +9,7 @@
     .PARAMETER Source
         Config source:
         RabbitMqConfig to view module variable
-        PSRabbitMq.xml to view PSRabbitMq.xml
+        PSRabbitMq.xml to view PSRabbitMq.xml from "$env:APPDATA\PSRabbitMq.xml"
 
     .FUNCTIONALITY
         RabbitMq
@@ -19,20 +19,14 @@
         [ValidateSet('RabbitMqConfig','PSRabbitMq.xml')]
         [string]$Source = "RabbitMqConfig"
     )
-
-    #handle PS2
-    if(-not $PSScriptRoot)
-    {
-        $PSScriptRoot = Split-Path $MyInvocation.MyCommand.Path -Parent
-    }
-
+    
     if($Source -eq "RabbitMqConfig")
     {
         $Script:RabbitMqConfig
     }
     else
     {
-        Import-Clixml -Path "$PSScriptRoot\PSRabbitMq.xml"
+        Import-Clixml -Path "$env:APPDATA\PSRabbitMq.xml"
     }
 
 }

--- a/PSRabbitMq/PSRabbitMQ.psm1
+++ b/PSRabbitMq/PSRabbitMQ.psm1
@@ -1,4 +1,10 @@
-﻿#Get public and private function definition files.
+﻿#handle PS2
+if(-not $PSScriptRoot)
+{
+    $PSScriptRoot = Split-Path $MyInvocation.MyCommand.Path -Parent
+}
+
+#Get public and private function definition files.
     $Public  = Get-ChildItem $PSScriptRoot\*.ps1 -ErrorAction SilentlyContinue 
     $Private = Get-ChildItem $PSScriptRoot\Private\*.ps1 -ErrorAction SilentlyContinue 
 
@@ -16,24 +22,19 @@
     }
     
 #Create / Read config
-    #handle PS2
-    if(-not $PSScriptRoot)
-    {
-        $PSScriptRoot = Split-Path $MyInvocation.MyCommand.Path -Parent
-    }
 
-    if(-not (Test-Path -Path "$PSScriptRoot\PSRabbitMq.xml" -ErrorAction SilentlyContinue))
+    if(-not (Test-Path -Path "$env:APPDATA\PSRabbitMq.xml" -ErrorAction SilentlyContinue))
     {
         Try
         {
-            Write-Warning "Did not find config file $PSScriptRoot\PSRabbitMq.xml, attempting to create"
+            Write-Warning "Did not find config file $env:APPDATA\PSRabbitMq.xml, attempting to create"
             [pscustomobject]@{
                 ComputerName = $null
-            } | Export-Clixml -Path "$PSScriptRoot\PSRabbitMq.xml" -Force -ErrorAction Stop
+            } | Export-Clixml -Path "$env:APPDATA\PSRabbitMq.xml" -Force -ErrorAction Stop
         }
         Catch
         {
-            Write-Warning "Failed to create config file $PSScriptRoot\PSRabbitMq.xml: $_"
+            Write-Warning "Failed to create config file $env:APPDATA\PSRabbitMq.xml: $_"
         }
     }
     
@@ -42,7 +43,7 @@
     {
         #Import the config
         $RabbitMqConfig = $null
-        $RabbitMqConfig = Get-RabbitMqConfig -Source PSRabbitMq.xml -ErrorAction Stop | Select -Property ComputerName
+        $RabbitMqConfig = Get-RabbitMqConfig -Source PSRabbitMq.xml -ErrorAction Stop | Select-Object -Property ComputerName
     }
     Catch
     {   
@@ -50,4 +51,4 @@
     }
 
 # Modules
-Export-ModuleMember -Function $($Public | Select -ExpandProperty BaseName) -Alias *
+Export-ModuleMember -Function $($Public | Select-Object -ExpandProperty BaseName) -Alias *

--- a/PSRabbitMq/Set-RabbitMqConfig.ps1
+++ b/PSRabbitMq/Set-RabbitMqConfig.ps1
@@ -18,7 +18,7 @@
         Set-RabbitMqConfig -ComputerName "rabbitmq.contoso.com"
 
     .Example
-        Set-RabbitMqConfig -ComputerName "rabbitmq.contoso.com" -Persist
+        Set-RabbitMqConfig -ComputerName "rabbitmq.contoso.com" -NoPersist
 
     .FUNCTIONALITY
         RabbitMq
@@ -26,6 +26,8 @@
     [cmdletbinding()]
     param(
         [string]$ComputerName,
+        [ValidateSet("CurrentUser","System")]
+        [string]$Scope = "CurrentUser",
         [switch]$NoPersist
     )
 
@@ -37,8 +39,15 @@
     #If Persist was specified and the Variable is not Empty
     if(-not($NoPersist) -and (-not([String]::IsNullOrEmpty($Script:RabbitMqConfig.ComputerName))))
     {
-        Write-Verbose "Writing current RabbitMQConfig to: $env:APPDATA\PSRabbitMq.xml"
-        $Script:RabbitMqConfig | Export-Clixml -Path "$env:APPDATA\PSRabbitMq.xml" -Force
+        if($Scope -eq "CurrentUser"){
+            Write-Verbose "Writing current RabbitMQConfig to: $env:APPDATA\PSRabbitMq.xml"
+            $Script:RabbitMqConfig | Export-Clixml -Path "$env:APPDATA\PSRabbitMq.xml" -Force
+        }
+        elseif($Scope -eq "System"){
+            Write-Verbose "Writing current RabbitMQConfig to: $env:PROGRAMDATA\PSRabbitMq.xml"
+            $Script:RabbitMqConfig | Export-Clixml -Path "$env:PROGRAMDATA\PSRabbitMq.xml" -Force
+        }
+        
     }
 
 }

--- a/PSRabbitMq/Set-RabbitMqConfig.ps1
+++ b/PSRabbitMq/Set-RabbitMqConfig.ps1
@@ -11,15 +11,24 @@
     .PARAMETER ComputerName
         Specify a ComputerName to use
 
+    .PARAMETER Persist
+        Exports the current RabbitMQConfig to $PSScriptRoot\PSRabbitMq.xml
+        
+        (Default: $PSScriptRoot = ModulePath)
+
     .Example
         Set-RabbitMqConfig -ComputerName "rabbitmq.contoso.com"
+
+    .Example
+        Set-RabbitMqConfig -ComputerName "rabbitmq.contoso.com" -Persist
 
     .FUNCTIONALITY
         RabbitMq
     #>
     [cmdletbinding()]
     param(
-        [string]$ComputerName
+        [string]$ComputerName,
+        [switch]$Persist
     )
 
     #handle PS2
@@ -33,6 +42,18 @@
         $Script:RabbitMqConfig.ComputerName = $ComputerName
     }
 
-    $Script:RabbitMqConfig | Export-Clixml -Path "$PSScriptRoot\PSRabbitMq.xml" -force
+    #If Persist was specified and the Variable is not Empty
+    if($Persist -and (-not([String]::IsNullOrEmpty($Script:RabbitMqConfig.ComputerName))))
+    {
+        try
+        {
+            Write-Verbose "Writing current RabbitMQConfig to: $PSScriptRoot\PSRabbitMq.xml"
+            $Script:RabbitMqConfig | Export-Clixml -Path "$PSScriptRoot\PSRabbitMq.xml" -Force
+        }
+        catch
+        {
+            Write-Warning "Your configuration was saved for the current session, but you need to run Powershell with Administrator permissions to persist this Configuration to $PSScriptRoot\PSRabbitMq.xml!"
+        }
+    }
 
 }

--- a/PSRabbitMq/Set-RabbitMqConfig.ps1
+++ b/PSRabbitMq/Set-RabbitMqConfig.ps1
@@ -11,10 +11,8 @@
     .PARAMETER ComputerName
         Specify a ComputerName to use
 
-    .PARAMETER Persist
-        Exports the current RabbitMQConfig to $PSScriptRoot\PSRabbitMq.xml
-        
-        (Default: $PSScriptRoot = ModulePath)
+    .PARAMETER NoPersist
+        Disables the export of the current RabbitMQConfig to $env:APPDATA\PSRabbitMq.xml                
 
     .Example
         Set-RabbitMqConfig -ComputerName "rabbitmq.contoso.com"
@@ -28,14 +26,8 @@
     [cmdletbinding()]
     param(
         [string]$ComputerName,
-        [switch]$Persist
+        [switch]$NoPersist
     )
-
-    #handle PS2
-    if(-not $PSScriptRoot)
-    {
-        $PSScriptRoot = Split-Path $MyInvocation.MyCommand.Path -Parent
-    }
 
     If($PSBoundParameters.ContainsKey('ComputerName'))
     {
@@ -43,17 +35,10 @@
     }
 
     #If Persist was specified and the Variable is not Empty
-    if($Persist -and (-not([String]::IsNullOrEmpty($Script:RabbitMqConfig.ComputerName))))
+    if(-not($NoPersist) -and (-not([String]::IsNullOrEmpty($Script:RabbitMqConfig.ComputerName))))
     {
-        try
-        {
-            Write-Verbose "Writing current RabbitMQConfig to: $PSScriptRoot\PSRabbitMq.xml"
-            $Script:RabbitMqConfig | Export-Clixml -Path "$PSScriptRoot\PSRabbitMq.xml" -Force
-        }
-        catch
-        {
-            Write-Warning "Your configuration was saved for the current session, but you need to run Powershell with Administrator permissions to persist this Configuration to $PSScriptRoot\PSRabbitMq.xml!"
-        }
+        Write-Verbose "Writing current RabbitMQConfig to: $env:APPDATA\PSRabbitMq.xml"
+        $Script:RabbitMqConfig | Export-Clixml -Path "$env:APPDATA\PSRabbitMq.xml" -Force
     }
 
 }

--- a/Tests/Get-RabbitMQConfig.Tests.ps1
+++ b/Tests/Get-RabbitMQConfig.Tests.ps1
@@ -19,9 +19,21 @@ Describe "Get-RabbitMqConfig" {
 
     context "Getting the persistent RabbitMQ Configuration"{
 
-        It "gets the current persistent Configuration"{
+        It "gets the current persistent Configuration from Old 'PSRabbitMq.xml' (AppData)"{
             Mock Import-CliXml {}
             $currentConfig = Get-RabbitMqConfig -Source "PSRabbitMq.xml"
+            Assert-MockCalled -CommandName Import-CliXml -Times 1
+        }
+
+        It "gets the current persistent Configuration from CurrentUser"{
+            Mock Import-CliXml {}
+            $currentConfig = Get-RabbitMqConfig -Source "CurrentUser"
+            Assert-MockCalled -CommandName Import-CliXml -Times 1
+        }
+
+        It "gets the current persistent Configuration from System"{
+            Mock Import-CliXml {}
+            $currentConfig = Get-RabbitMqConfig -Source "System"
             Assert-MockCalled -CommandName Import-CliXml -Times 1
         }
     }

--- a/Tests/Get-RabbitMQConfig.Tests.ps1
+++ b/Tests/Get-RabbitMQConfig.Tests.ps1
@@ -1,0 +1,28 @@
+﻿$here = Split-Path -Parent $MyInvocation.MyCommand.Path
+$sut = (Split-Path -Leaf $MyInvocation.MyCommand.Path).Replace(".Tests.", ".")
+
+. "$here\TestSetup.ps1"
+. "$here\..\PSRabbitMQ\$sut"
+
+Describe "Get-RabbitMqConfig" {
+
+    context "Getting current RabbitMQ Configuration" {
+        It "gets the current Configuration"{
+            $Script:RabbitMqConfig = [pscustomobject]@{
+                ComputerName = "rabbitmq.contoso.com"
+            }
+
+            $currentConfig = Get-RabbitMqConfig -Source "RabbitMQConfig"
+            $currentConfig.ComputerName | Should be "rabbitmq.contoso.com"
+        }
+    }
+
+    context "Getting the persistent RabbitMQ Configuration"{
+
+        It "gets the current persistent Configuration"{
+            Mock Import-CliXml {}
+            $currentConfig = Get-RabbitMqConfig -Source "PSRabbitMq.xml"
+            Assert-MockCalled -CommandName Import-CliXml -Times 1
+        }
+    }
+}

--- a/Tests/Set-RabbitMQConfig.Tests.ps1
+++ b/Tests/Set-RabbitMQConfig.Tests.ps1
@@ -19,9 +19,15 @@ Describe "Set-RabbitMqConfig" {
 
     context "Persisting the RabbitMQ Configuration"{
 
-        It "persists the current Configuration"{
+        It "persists the current Configuration to AppData"{
             Mock Export-CliXml {}
-            Set-RabbitMqConfig
+            Set-RabbitMqConfig -Scope CurrentUser
+            Assert-MockCalled -CommandName Export-CliXml -Times 1
+        }
+
+        It "persists the current Configuration to ProgramData"{
+            Mock Export-CliXml {}
+            Set-RabbitMqConfig -Scope System
             Assert-MockCalled -CommandName Export-CliXml -Times 1
         }
     }

--- a/Tests/Set-RabbitMQConfig.Tests.ps1
+++ b/Tests/Set-RabbitMQConfig.Tests.ps1
@@ -12,7 +12,7 @@ Describe "Set-RabbitMqConfig" {
                 ComputerName = $null
             }
             $computerName = "rabbitmq.contoso.com"
-            Set-RabbitMqConfig -ComputerName $computerName
+            Set-RabbitMqConfig -ComputerName $computerName -NoPersist
             $Script:RabbitMqConfig.ComputerName | Should be $computerName
         }        
     }
@@ -21,13 +21,8 @@ Describe "Set-RabbitMqConfig" {
 
         It "persists the current Configuration"{
             Mock Export-CliXml {}
-            Set-RabbitMqConfig -Persist
+            Set-RabbitMqConfig
             Assert-MockCalled -CommandName Export-CliXml -Times 1
-        }
-
-        It "handles an UnauthorizedAccessException"{
-            Mock Export-Clixml {throw [System.UnauthorizedAccessException]}
-            {Set-RabbitMqConfig -Persist -WarningAction SilentlyContinue} | Should Not Throw            
         }
     }
 }

--- a/Tests/Set-RabbitMQConfig.Tests.ps1
+++ b/Tests/Set-RabbitMQConfig.Tests.ps1
@@ -1,0 +1,33 @@
+﻿$here = Split-Path -Parent $MyInvocation.MyCommand.Path
+$sut = (Split-Path -Leaf $MyInvocation.MyCommand.Path).Replace(".Tests.", ".")
+
+. "$here\TestSetup.ps1"
+. "$here\..\PSRabbitMQ\$sut"
+
+Describe "Set-RabbitMqConfig" {
+
+    context "Setting current RabbitMQ Configuration" {
+        It "sets the current Configuration"{
+            $Script:RabbitMqConfig = [pscustomobject]@{
+                ComputerName = $null
+            }
+            $computerName = "rabbitmq.contoso.com"
+            Set-RabbitMqConfig -ComputerName $computerName
+            $Script:RabbitMqConfig.ComputerName | Should be $computerName
+        }        
+    }
+
+    context "Persisting the RabbitMQ Configuration"{
+
+        It "persists the current Configuration"{
+            Mock Export-CliXml {}
+            Set-RabbitMqConfig -Persist
+            Assert-MockCalled -CommandName Export-CliXml -Times 1
+        }
+
+        It "handles an UnauthorizedAccessException"{
+            Mock Export-Clixml {throw [System.UnauthorizedAccessException]}
+            {Set-RabbitMqConfig -Persist -WarningAction SilentlyContinue} | Should Not Throw            
+        }
+    }
+}


### PR DESCRIPTION
Hi!

I was using PSRabbitMq, specifically Set-RabbitMqConfig, when I ran into an access denied error. I was using Powershell as a non-elevated user which effectively denied me access to C:\Program Files\WindowsPowershell\Modules\PsRabbitMQ\RabbitMqConfig.xml.

To fix this I added a "Persist" Switch to the Set-RabbitMqConfig function which causes the current configuration also the be written into the file (in addition to writing it to the variable) and warns the user if there happens an error while writing the config.
I also added some help text for the new parameter and a Tests file for the whole function.

Initially I wanted the catch block to only catch exceptions of the type System.UnauthorizedAccessException, which worked fine, but Pester doesn't seem to respect the Exception Type I specify and just generates a generic Exception, so I had to remove the catch error type statement. If someone knows how to work around this, I would be glad if you could share your knowledge ;-)

Regards,
Raphael
