### PR TITLE
Fix dll file name case to be installable on linux

### DIFF
--- a/PSRabbitMq/PSRabbitMQ.psd1
+++ b/PSRabbitMq/PSRabbitMQ.psd1
@@ -40,7 +40,7 @@ Description = 'Send and receive messages using a RabbitMQ server'
 # RequiredModules = @()
 
 # Assemblies that must be loaded prior to importing this module
-RequiredAssemblies = @('lib\RabbitMQ.Client.Dll')
+RequiredAssemblies = @('lib\RabbitMQ.Client.dll')
 
 # Script files (.ps1) that are run in the caller's environment prior to importing this module
 # ScriptsToProcess = @()


### PR DESCRIPTION
DLL file name suffix case issue made installation not work on linux environments.