### PR TITLE
Register-RabbitMqEvent: adding parameter vhost to the powershell job

### DIFF
--- a/PSRabbitMq/Register-RabbitMqEvent.ps1
+++ b/PSRabbitMq/Register-RabbitMqEvent.ps1
@@ -156,7 +156,7 @@
         $ListenerJobName = "RabbitMq_${ComputerName}_${Exchange}_${Key}"
     }
 
-    $ArgList = $ComputerName, $Exchange, $ExchangeType, $Key, $Action, $Credential, $CertPath, $CertPassphrase, $Ssl, $LoopInterval, $QueueName, $Durable, $Exclusive, $AutoDelete, $RequireAck,$prefetchSize,$prefetchCount,$global,[bool]$IncludeEnvelope,$ActionData
+    $ArgList = $ComputerName, $Exchange, $ExchangeType, $Key, $Action, $Credential, $CertPath, $CertPassphrase, $Ssl, $LoopInterval, $QueueName, $Durable, $Exclusive, $AutoDelete, $RequireAck,$prefetchSize,$prefetchCount,$global,[bool]$IncludeEnvelope,$ActionData,$vhost
 
     Start-Job -Name $ListenerJobName -ArgumentList $Arglist -ScriptBlock {
         param(
@@ -181,7 +181,8 @@
             $prefetchCount,
             $global,
             $IncludeEnvelope,
-            $ActionData
+            $ActionData,
+            $vhost
         )
 
         $ActionSB = [System.Management.Automation.ScriptBlock]::Create($Action)


### PR DESCRIPTION
## Description
Added vhost to the argument list and to the job parameter list.

## Motivation and Context
Since the powershell jobs run in a different scope, vhost was always null since it was not part of the job parameter list, despite the vhost parameter being exposed on the Register-RabbitMqEvent command.