### PR TITLE
Added port number to Register-RabbitMq Event and Send-RabbitMqMessage

### DIFF
--- a/PSRabbitMq/PSRabbitMQ.psd1
+++ b/PSRabbitMq/PSRabbitMQ.psd1
@@ -1,9 +1,9 @@
-@{
+﻿@{
 # Script module or binary module file associated with this manifest
 ModuleToProcess = 'PSRabbitMQ.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.3.3'
+ModuleVersion = '0.3.4'
 
 # ID used to uniquely identify this module
 GUID = '41d4d893-5070-44f2-9cf7-9d80020603b1'

--- a/PSRabbitMq/Register-RabbitMqEvent.ps1
+++ b/PSRabbitMq/Register-RabbitMqEvent.ps1
@@ -165,7 +165,7 @@
         $ListenerJobName = "RabbitMq_${ComputerName}_${Exchange}_${Key}"
     }
 
-    $ArgList = $ComputerName, $Exchange, $ExchangeType, $Key, $Action, $Credential, $CertPath, $CertPassphrase, $Ssl, $LoopInterval, $QueueName, $Durable, $Exclusive, $AutoDelete, $RequireAck,$prefetchSize,$prefetchCount,$global,[bool]$IncludeEnvelope,$ActionData,$vhost,$Port
+    $ArgList = $ComputerName, $Exchange, $ExchangeType, $Key, $Action, $Credential, $CertPath, $CertPassphrase, $Ssl, $LoopInterval, $QueueName, $Durable, $Exclusive, $AutoDelete, $Arguments, $RequireAck, $prefetchSize,$prefetchCount,$global,[bool]$IncludeEnvelope,$ActionData,$vhost,$Port
     
     Start-Job -Name $ListenerJobName -ArgumentList $Arglist -ScriptBlock {
         param(

--- a/PSRabbitMq/Register-RabbitMqEvent.ps1
+++ b/PSRabbitMq/Register-RabbitMqEvent.ps1
@@ -158,7 +158,7 @@
 
         $ActionData,
         
-        [int16]$Port
+        [int16]$Port = 5672
     )
 
     if ( !$PSBoundParameters.ContainsKey('ListenerJobName') ) {

--- a/PSRabbitMq/Register-RabbitMqEvent.ps1
+++ b/PSRabbitMq/Register-RabbitMqEvent.ps1
@@ -72,6 +72,9 @@
         Include the Message envelope (Metadata) of the message. If ommited, only
         the payload (body of the message) is returned
 
+    .PARAMETER Port
+        Port number used by the RabbitMq (AMQP) Server
+
     .EXAMPLE
         Register-RabbitMqEvent -ComputerName RabbitMq.Contoso.com -Exchange TestFanExc -Key 'wat' -Credential $Credential -Ssl Tls12 -QueueName TestQueue -Action {"HI! $_"}
 
@@ -153,15 +156,17 @@
 
         [string]$ListenerJobName, 
 
-        $ActionData
+        $ActionData,
+        
+        [int16]$Port
     )
 
     if ( !$PSBoundParameters.ContainsKey('ListenerJobName') ) {
         $ListenerJobName = "RabbitMq_${ComputerName}_${Exchange}_${Key}"
     }
 
-    $ArgList = $ComputerName, $Exchange, $ExchangeType, $Key, $Action, $Credential, $CertPath, $CertPassphrase, $Ssl, $LoopInterval, $QueueName, $Durable, $Exclusive, $AutoDelete, $Arguments, $RequireAck,$prefetchSize,$prefetchCount,$global,[bool]$IncludeEnvelope,$ActionData,$vhost
-
+    $ArgList = $ComputerName, $Exchange, $ExchangeType, $Key, $Action, $Credential, $CertPath, $CertPassphrase, $Ssl, $LoopInterval, $QueueName, $Durable, $Exclusive, $AutoDelete, $RequireAck,$prefetchSize,$prefetchCount,$global,[bool]$IncludeEnvelope,$ActionData,$vhost,$Port
+    
     Start-Job -Name $ListenerJobName -ArgumentList $Arglist -ScriptBlock {
         param(
             $ComputerName,
@@ -187,7 +192,8 @@
             $global,
             $IncludeEnvelope,
             $ActionData,
-            $vhost
+            $vhost,
+            $Port
         )
 
         $ActionSB = [System.Management.Automation.ScriptBlock]::Create($Action)
@@ -196,7 +202,10 @@
             Import-Module PSRabbitMq
 
             #Build the connection and channel params
-            $ConnParams = @{ ComputerName = $ComputerName }
+            $ConnParams = @{ 
+                ComputerName = $ComputerName 
+                Port = $Port
+            }
             $ConnParams.Add('vhost',$vhost)
 
             $ChanParams = @{ Exchange = $Exchange }

--- a/PSRabbitMq/Send-RabbitMqMessage.ps1
+++ b/PSRabbitMq/Send-RabbitMqMessage.ps1
@@ -91,6 +91,9 @@
         
     .PARAMETER Headers
         message header field table
+    
+    .PARAMETER Port
+        Port number used by the RabbitMq (AMQP) Server
 
     .EXAMPLE
         Send-RabbitMqMessage -ComputerName RabbitMq.Contoso.com -Exchange MyExchange -Key "wat" -InputObject $Object
@@ -161,7 +164,9 @@
 
         [Int64]$TTL,
 
-        [hashtable]$headers
+        [hashtable]$headers,
+        
+        [int16] $Port
     )
     begin
     {
@@ -177,6 +182,7 @@
             'CertPassphrase' { $ConnParams.Add('CertPassphrase',$CertPassphrase)}
             'Credential'     { $ConnParams.Add('Credential',$Credential) }
             'vhost'          { $ConnParams.Add('vhost',$vhost) }
+            'Port'           { $ConnParams.Add('Port',$Port) }
         }
         Write-Verbose "Connection parameters: $($ConnParams | Out-String)"
 

--- a/PSRabbitMq/Send-RabbitMqMessage.ps1
+++ b/PSRabbitMq/Send-RabbitMqMessage.ps1
@@ -166,7 +166,7 @@
 
         [hashtable]$headers,
         
-        [int16] $Port
+        [int16] $Port = 5672
     )
     begin
     {

--- a/PSRabbitMq/Wait-RabbitMqMessage.ps1
+++ b/PSRabbitMq/Wait-RabbitMqMessage.ps1
@@ -11,6 +11,9 @@
 
         If SSL is specified, we use this as the SslOption server name as well.
 
+    .PARAMETER Port
+        Port number used by the RabbitMq (AMQP) Server
+
     .PARAMETER Exchange
         RabbitMq Exchange
 
@@ -89,7 +92,7 @@
     [Cmdletbinding(DefaultParameterSetName = 'NoQueueName')]
     param(
         [string]$ComputerName = $Script:RabbitMqConfig.ComputerName,
-        [int]$Port,
+        [int16]$Port = 5672,
 
         [parameter(Mandatory = $True)]
         [AllowEmptyString()]


### PR DESCRIPTION
## Description
Added the possibility to specify a different port number when using the Register-RabbitMq Event and Send-RabbitMqMessage functions.

## Motivation and Context
Not being able to specify a port other than the default ones (non-ssl and ssl).